### PR TITLE
fix: injector.py 注释清理 — 编号修正 + stub 标记移除 + docstring 补全 debug

### DIFF
--- a/injector.py
+++ b/injector.py
@@ -894,7 +894,7 @@ def _daily_turn_count_hint(fixed_cfg: dict, profile_path: str = "") -> str | Non
 
 
 # ---------------------------------------------------------------------------
-# Stub functions (P2 / P3)
+# Memory & Kanban helpers
 # ---------------------------------------------------------------------------
 
 
@@ -1091,6 +1091,7 @@ def inject_context(
         4.  Random variance
         5.  Memory recall
         6.  Kanban status (first-turn only)
+        7.  Debug summary (appended to LLM output via transform_llm_output hook)
 
     Returns {"context": "<assembled string>"} or None when there is nothing
     to inject.
@@ -1328,7 +1329,7 @@ def inject_context(
                 pass  # fail-open：表达向量失败不阻断后续注入
         # ──────────────────────────────────────────────────
 
-        # 5. Random variance
+        # 4. Random variance
         var_count = 0
         var_results = []
         if _is_enabled(modules, "variance"):


### PR DESCRIPTION
## 概述

修复 Issue #2 中的三个预存注释/docstring 问题。

## 修复内容

| # | 问题 | 文件 | 修改 |
|---|------|------|------|
| C03/C04 | 行内注释 `# 5.` 重复（Variance 和 Memory 共用编号） | [injector.py:1331](https://github.com/kenyonxu/hermes-persona/blob/f983ff9/injector.py#L1331) | `# 5.` → `# 4. Random variance` |
| C05 | `# Stub functions (P2 / P3)` 标记过时 | [injector.py:897](https://github.com/kenyonxu/hermes-persona/blob/f983ff9/injector.py#L897) | → `# Memory & Kanban helpers` |
| C06 | docstring 注入顺序缺少 debug 步骤 | [injector.py:1084-1094](https://github.com/kenyonxu/hermes-persona/blob/f983ff9/injector.py#L1084-L1094) | 新增 `7. Debug summary` |

## 测试

```
455 passed, 1 skipped
```

Closes #2